### PR TITLE
Correction de refresh de score

### DIFF
--- a/src/main/java/com/bmu/pronostics/web/rest/MatchResource.java
+++ b/src/main/java/com/bmu/pronostics/web/rest/MatchResource.java
@@ -200,7 +200,11 @@ public class MatchResource {
                 scoreDiffMatch = scoreDom - scoreVisit;
                 switch (scoreDiffMatch.compareTo(scorePronoDom - scorePronoVisit)) {
                 case WIN:
-                     pronostic.setPoints(1);
+                if(((scoreDom > scoreVisit) && (scorePronoDom > scorePronoVisit)) ||  ((scoreDom < scoreVisit) && (scorePronoDom < scorePronoVisit)))  {
+                    pronostic.setPoints(1);
+                   }else{
+                   pronostic.setPoints(0);
+                   }
                     break;
                 case DOUBLE_WIN:
                     if (scoreDom == scorePronoDom && scoreVisit == scorePronoVisit) {


### PR DESCRIPTION
Suite à un problème quand le match est 0-1 et que le prono est 1-0 => l'application accorde 1 pts alors que c'est 0 point